### PR TITLE
len has been increased by 1 in mkstr

### DIFF
--- a/elk.c
+++ b/elk.c
@@ -292,7 +292,7 @@ static jsval_t mkentity(struct js *js, jsoff_t b, const void *buf, size_t len) {
   memcpy(&js->mem[ofs], &b, sizeof(b));
   // Using memmove - in case we're stringifying data from the free JS mem
   if (buf != NULL) memmove(&js->mem[ofs + sizeof(b)], buf, len);
-  if ((b & 3) == T_STR) js->mem[ofs + sizeof(b) + len] = 0;  // 0-terminate
+  if ((b & 3) == T_STR) js->mem[ofs + sizeof(b) + len - 1] = 0;  // 0-terminate
   // printf("MKE: %u @ %u type %d\n", js->brk - ofs, ofs, b & 3);
   return mkval(b & 3, ofs);
 }


### PR DESCRIPTION
js code:

`
let timer_counter = "*";
let on_timer = function() {
    debug("on timer:" + timer_counter);
    timer_counter = timer_counter + "*";
    return timer_counter;
};
`

c code:

debug function
`
int debug_str(char *s)
{
  printf("debug: %s\n", s);
  return 0;
}
`

import to ELK

`
  js_set(js, js_glob(js), "debug", js_import(js, (uintptr_t) debug_str, "is"));
`

invoke

`
  int i = 0;
  for(i = 0; i < 10; i++){
    jsval_t v = js_eval(js, "on_timer();", ~0);
    printf("result on timer: %s\n", js_str(js, v));
  }
`

then, the output is like
*****s
******@

