### PR TITLE
Fix setprop bug

### DIFF
--- a/elk.c
+++ b/elk.c
@@ -320,9 +320,11 @@ static jsval_t setprop(struct js *js, jsval_t obj, jsval_t k, jsval_t v) {
   memcpy(buf, &koff, sizeof(koff));           // Initialize prop data: copy key
   memcpy(buf + sizeof(koff), &v, sizeof(v));  // Copy value
   jsoff_t brk = js->brk | T_OBJ;              // New prop offset
-  memcpy(&js->mem[head], &brk, sizeof(brk));  // Repoint head to the new prop
   // printf("PROP: %u -> %u\n", b, brk);
-  return mkentity(js, (b & ~3U) | T_PROP, buf, sizeof(buf));  // Create new prop
+  jsval_t res = mkentity(js, (b & ~3U) | T_PROP, buf, sizeof(buf));
+  if (!is_err(res))
+    memcpy(&js->mem[head], &brk, sizeof(brk));  // Repoint head to the new prop
+  return res;
 }
 
 // Return T_OBJ/T_PROP/T_STR entity size based on the first word in memory


### PR DESCRIPTION
## Problem
In the original setprop, the object's property list head pointer (js->mem[head]) was updated to point to js->brk before mkentity was called to actually allocate the new property entity. If mkentity failed due to OOM (out of memory), the object's head pointer was left dangling — pointing to memory that was never successfully allocated as a valid property. Any subsequent access to the object's properties would follow this dangling pointer, resulting in a Use-After-Free / out-of-bounds read.
```c
// BEFORE (vulnerable):
jsoff_t brk = js->brk | T_OBJ;
memcpy(&js->mem[head], &brk, sizeof(brk));  // Head updated BEFORE allocation
return mkentity(js, ...);                    // Allocation may fail -> dangling pointer
```

## Fix
Reorder the operations so that mkentity is called first, and the object's head pointer is only updated if the allocation succeeds:
```c
// AFTER (fixed):
jsoff_t brk = js->brk | T_OBJ;
jsval_t res = mkentity(js, ...);             // Allocate first
if (!is_err(res))
    memcpy(&js->mem[head], &brk, sizeof(brk));  // Update head only on success
return res;
```

This ensures the property list remains in a consistent state when allocation fails.