### PR TITLE
Allow `return` at the top level of a `js_eval` snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ int main(void) {
 - Objects: `let obj = {f: function(x) { return x * 2}}; obj.f(3);`
 - Every statement must end with a semicolon `;`
 - Strings are binary data chunks, not Unicode strings: `'Київ'.length === 8`
+- Top-level `return`: `return;` and `return <expr>;` outside any function
+  body exit the current `js_eval` snippet (see below).
 
 ## Not supported features
 
@@ -110,6 +112,44 @@ int main(void) {
 - No `=>` functions. Use `let f = function(...) {...};`
 - No arrays, closures, prototypes, `this`, `new`, `delete`
 - No standard library: no `Date`, `Regexp`, `Function`, `String`, `Number`
+
+## Top-level `return`
+
+A `return` statement outside any function body is allowed at the top level
+of a `js_eval` snippet, where it acts as **"end of snippet"**: parsing jumps
+to the end of the buffer, the rest of the code is skipped, and the value of
+`return <expr>` becomes the result of `js_eval`. This supports the natural
+early-exit idiom in embedded scripts that are passed directly to `js_eval`
+without a wrapping function:
+
+```javascript
+if (!sensorReady) { return; }   // bail out early
+processSensor();                // ...rest of the snippet
+```
+
+```c
+js_eval(js, "return", ~0U);          // -> undefined
+js_eval(js, "return;", ~0U);         // -> undefined
+js_eval(js, "return 2;", ~0U);       // -> 2
+js_eval(js, "{ return; }", ~0U);     // -> undefined  (works inside a block)
+js_eval(js, "return 1; 2;", ~0U);    // -> 1          (short-circuits the rest)
+```
+
+Behaviour notes:
+
+- Bare `return`, `return;`, `return}`, and `return<EOF>` all exit cleanly
+  with `undefined`. The idiomatic `if (cond) return;` short-circuits the
+  remainder of the snippet rather than silently falling through.
+- The internal `F_RETURN` flag is still only set inside `F_CALL` (i.e.
+  inside an actual function call). It does not leak across `js_eval` calls,
+  and function-body return semantics are unchanged: a `return` inside
+  `(function(){...})()` exits the function, not the surrounding snippet.
+
+```javascript
+// Function-body return is scoped to the function: only the function exits,
+// not the surrounding snippet.
+(function(){ return 1; })(); 99    // -> 99
+```
 
 ## Performance
 

--- a/elk.c
+++ b/elk.c
@@ -1285,12 +1285,21 @@ static jsval_t js_continue(struct js *js) {
 static jsval_t js_return(struct js *js) {
   uint8_t exe = !(js->flags & F_NOEXEC);
   js->consumed = 1;
-  if (exe && !(js->flags & F_CALL)) return js_mkerr(js, "not in func");
-  if (next(js) == TOK_SEMICOLON) return js_mkundef();
+  // Allow `return` at the top level as well as inside a function call:
+  // at the top level, treat it as "end of snippet". This supports the
+  // common early-exit idiom in embedded `js_eval` snippets.
+  uint8_t tok = next(js);
+  if (tok == TOK_SEMICOLON || tok == TOK_RBRACE || tok == TOK_EOF) {
+    if (exe) {
+      js->pos = js->clen;                            // Shift to the end - exit the code snippet
+      if (js->flags & F_CALL) js->flags |= F_RETURN; // Tell caller we've executed
+    }
+    return js_mkundef();
+  }
   jsval_t res = resolveprop(js, js_expr(js));
   if (exe) {
-    js->pos = js->clen;     // Shift to the end - exit the code snippet
-    js->flags |= F_RETURN;  // Tell caller we've executed
+    js->pos = js->clen;                            // Shift to the end - exit the code snippet
+    if (js->flags & F_CALL) js->flags |= F_RETURN; // Tell caller we've executed
   }
   return resolveprop(js, res);
 }

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -354,11 +354,14 @@ static void test_funcs(void) {
   assert(ev(js, "f(,)", "ERROR: parse error"));
   assert(ev(js, "f(1,)", "ERROR: parse error"));
   assert(ev(js, "f(,2)", "ERROR: parse error"));
-  assert(ev(js, "return", "ERROR: not in func"));
-  assert(ev(js, "return 2;", "ERROR: not in func"));
-  assert(ev(js, "{ return } ", "ERROR: not in func"));
+  // Top-level `return` exits the snippet with an optional value
+  assert(ev(js, "return", "undefined"));
+  assert(ev(js, "return;", "undefined"));
+  assert(ev(js, "return 2;", "2"));
+  assert(ev(js, "{ return; } ", "undefined"));
+  assert(ev(js, "return 1; 2;", "1"));   // return short-circuits the rest
   assert(ev(js, "f(3,4)", "17"));
-  assert(ev(js, "return", "ERROR: not in func"));
+  assert(ev(js, "return", "undefined"));
   assert(ev(js, "(function(){})()", "undefined"));
   assert(ev(js, "(function(){})(1,2,3)", "undefined"));
   assert(ev(js, "(function(){1;})(1,2,3)", "undefined"));


### PR DESCRIPTION
Previously, a `return` statement outside a function call failed with
"not in func". This is inconvenient for embedded use cases where user
code is passed directly to `js_eval` (not wrapped in a function) and a
natural early-exit idiom is:

    if (cond) { return; }

`js_return` now treats a top-level `return` as "end of snippet": it
jumps `pos` to `clen`, so the remainder of the code is skipped.
`F_RETURN` is still set only inside a function call (`F_CALL`), so the
flag never leaks into subsequent top-level `js_eval` calls and
`call_js`'s existing check at the end of a function body continues to
work unchanged.

The value-less form (`return`, `return;`, `return}`, `return<EOF>`) now
also exits the snippet — upstream only did this when a value
expression followed, which made the idiomatic `return;` silently
fall through instead of short-circuiting.

Unit tests updated to assert the new top-level behaviour alongside the
existing function-body tests.