### PR TITLE
Preserve runtime errors over the statement-terminator check

### DIFF
--- a/elk.c
+++ b/elk.c
@@ -1317,6 +1317,7 @@ static jsval_t js_stmt(struct js *js) {
     default:            res = resolveprop(js, js_expr(js)); break;
   }
   //printf("STMT [%.*s] -> %s, tok %d, flags %d\n", (int) (js->pos - pos), &js->code[pos], js_str(js, res), next(js), js->flags);
+  if (is_err(res)) return res;  // Preserve the original runtime error; do not clobber it with a "; expected" parse error below.
   if (next(js) != TOK_SEMICOLON && next(js) != TOK_EOF && next(js) != TOK_RBRACE) return js_mkerr(js, "; expected");
   js->consumed = 1;
   // clang-format on

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -543,6 +543,12 @@ static void test_c_funcs(void) {
   assert(ev(js, "gt(0.78,-12.5)", "true"));
   // assert(ev(js, "gt(2,2)", "true"));
 
+  // A runtime error returned from a C function should be preserved even when
+  // it appears as part of a larger expression (the trailing operator/operand
+  // must not be misreported as "; expected").
+  assert(ev(js, "gt() * 2", "ERROR: doh"));
+  assert(ev(js, "1 + gt(null, 1)", "ERROR: doh"));
+
   js_set(js, js_glob(js), "set_timer", js_mkfun(js_set_timer));
   js_eval(js, "let v = 0, f = function(x) { v+=x; };", ~0UL);
   js_eval(js, "set_timer('f');", ~0UL);


### PR DESCRIPTION
## Summary

When a native (C) function returns an error mid-expression (e.g. `myCFunc(badArg) * 60;`), the engine currently reports `"; expected"` instead of the original error message.

## Reproducing

```c
static jsval_t bad(struct js *js, jsval_t *args, int nargs) {
  (void) args; (void) nargs;
  return js_mkerr(js, "boom");
}
...
js_set(js, js_glob(js), "bad", js_mkfun(bad));
js_eval(js, "bad() * 2;", ~0UL);
// Expected: "ERROR: boom"
// Actual:   "ERROR: ; expected"
```

## Root cause

1. The native function calls `js_mkerr(...)` which sets `js->tok = TOK_EOF` and `js->pos = js->clen` to short-circuit further parsing.
2. `do_call_op` restores the parser state after the call returns (so the parser is sitting on the `*` token after `)`).
3. `RTL_BINOP` / `LTR_BINOP` short-circuit on `is_err(res)` and do **not** consume the trailing operator.
4. `js_stmt`'s terminator check
   ```c
   if (next(js) != TOK_SEMICOLON && next(js) != TOK_EOF && next(js) != TOK_RBRACE)
     return js_mkerr(js, "; expected");
   ```
   does not gate on `is_err(res)`, sees the unconsumed `*`, and overwrites the real error (`errmsg` is a single shared buffer).

## Fix

Short-circuit in `js_stmt` when `res` is already an error. One-line change in `elk.c`; existing terminator behavior for non-error statements is unchanged.

## Test plan

- [x] Added two unit tests in `test_c_funcs` covering C-function errors embedded in larger expressions (`gt() * 2`, `1 + gt(null, 1)`).
- [ ] Existing tests for `"; expected"` (e.g. `"1 2"`, `"1 + 2 3"`, `"{1}"`, `function(){1}`) still pass — they exercise expression-level non-error results followed by stray tokens, which is unaffected by this patch.
- [ ] CI run against full test matrix (gcc, g++, MSVC, MinGW).